### PR TITLE
fix(lobby-endpoint): Removed places from lobby endpoint

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -167,7 +167,7 @@ const docTemplate = `{
                     "200": {
                         "description": "lobby data",
                         "schema": {
-                            "$ref": "#/definitions/domain.Lobby"
+                            "$ref": "#/definitions/lobby.lobbyOutput"
                         }
                     },
                     "400": {
@@ -798,6 +798,38 @@ const docTemplate = `{
                 }
             }
         },
+        "lobby.lobbyOutput": {
+            "type": "object",
+            "properties": {
+                "createdAt": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "location": {
+                    "$ref": "#/definitions/domain.Coordinate"
+                },
+                "priceAvg": {
+                    "type": "integer"
+                },
+                "state": {
+                    "type": "string"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/domain.Tag"
+                    }
+                },
+                "users": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/domain.User"
+                    }
+                }
+            }
+        },
         "lobby.nearestLobbyOutput": {
             "type": "object",
             "properties": {
@@ -805,7 +837,7 @@ const docTemplate = `{
                     "type": "number"
                 },
                 "lobby": {
-                    "$ref": "#/definitions/domain.Lobby"
+                    "$ref": "#/definitions/lobby.lobbyOutput"
                 }
             }
         },

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -43,7 +43,7 @@ const docTemplate = `{
                     "200": {
                         "description": "Saved lobby",
                         "schema": {
-                            "$ref": "#/definitions/domain.Lobby"
+                            "$ref": "#/definitions/usecase.LobbyOutput"
                         }
                     },
                     "400": {
@@ -83,13 +83,13 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/domain.Lobby"
+                            "$ref": "#/definitions/usecase.LobbyOutput"
                         }
                     },
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/domain.Lobby"
+                            "$ref": "#/definitions/usecase.LobbyOutput"
                         }
                     },
                     "400": {
@@ -167,7 +167,7 @@ const docTemplate = `{
                     "200": {
                         "description": "lobby data",
                         "schema": {
-                            "$ref": "#/definitions/lobby.lobbyOutput"
+                            "$ref": "#/definitions/usecase.LobbyOutput"
                         }
                     },
                     "400": {
@@ -647,50 +647,6 @@ const docTemplate = `{
                 }
             }
         },
-        "domain.Lobby": {
-            "type": "object",
-            "properties": {
-                "createdAt": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "location": {
-                    "$ref": "#/definitions/domain.Coordinate"
-                },
-                "places": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/domain.Place"
-                    }
-                },
-                "priceAvg": {
-                    "type": "integer"
-                },
-                "state": {
-                    "type": "string"
-                },
-                "swipes": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/domain.Swipe"
-                    }
-                },
-                "tags": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/domain.Tag"
-                    }
-                },
-                "users": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/domain.User"
-                    }
-                }
-            }
-        },
         "domain.Place": {
             "type": "object",
             "properties": {
@@ -741,26 +697,6 @@ const docTemplate = `{
                 }
             }
         },
-        "domain.Swipe": {
-            "type": "object",
-            "properties": {
-                "cardID": {
-                    "type": "integer"
-                },
-                "id": {
-                    "type": "integer"
-                },
-                "lobbyID": {
-                    "type": "string"
-                },
-                "type": {
-                    "type": "string"
-                },
-                "userID": {
-                    "type": "string"
-                }
-            }
-        },
         "domain.Tag": {
             "type": "object",
             "properties": {
@@ -798,7 +734,29 @@ const docTemplate = `{
                 }
             }
         },
-        "lobby.lobbyOutput": {
+        "lobby.nearestLobbyOutput": {
+            "type": "object",
+            "properties": {
+                "distance": {
+                    "type": "number"
+                },
+                "lobby": {
+                    "$ref": "#/definitions/usecase.LobbyOutput"
+                }
+            }
+        },
+        "usecase.FindLobbyInput": {
+            "type": "object",
+            "properties": {
+                "dist": {
+                    "type": "number"
+                },
+                "location": {
+                    "$ref": "#/definitions/domain.Coordinate"
+                }
+            }
+        },
+        "usecase.LobbyOutput": {
             "type": "object",
             "properties": {
                 "createdAt": {
@@ -827,28 +785,6 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/domain.User"
                     }
-                }
-            }
-        },
-        "lobby.nearestLobbyOutput": {
-            "type": "object",
-            "properties": {
-                "distance": {
-                    "type": "number"
-                },
-                "lobby": {
-                    "$ref": "#/definitions/lobby.lobbyOutput"
-                }
-            }
-        },
-        "usecase.FindLobbyInput": {
-            "type": "object",
-            "properties": {
-                "dist": {
-                    "type": "number"
-                },
-                "location": {
-                    "$ref": "#/definitions/domain.Coordinate"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -159,7 +159,7 @@
                     "200": {
                         "description": "lobby data",
                         "schema": {
-                            "$ref": "#/definitions/domain.Lobby"
+                            "$ref": "#/definitions/lobby.lobbyOutput"
                         }
                     },
                     "400": {
@@ -790,6 +790,38 @@
                 }
             }
         },
+        "lobby.lobbyOutput": {
+            "type": "object",
+            "properties": {
+                "createdAt": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "location": {
+                    "$ref": "#/definitions/domain.Coordinate"
+                },
+                "priceAvg": {
+                    "type": "integer"
+                },
+                "state": {
+                    "type": "string"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/domain.Tag"
+                    }
+                },
+                "users": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/domain.User"
+                    }
+                }
+            }
+        },
         "lobby.nearestLobbyOutput": {
             "type": "object",
             "properties": {
@@ -797,7 +829,7 @@
                     "type": "number"
                 },
                 "lobby": {
-                    "$ref": "#/definitions/domain.Lobby"
+                    "$ref": "#/definitions/lobby.lobbyOutput"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -35,7 +35,7 @@
                     "200": {
                         "description": "Saved lobby",
                         "schema": {
-                            "$ref": "#/definitions/domain.Lobby"
+                            "$ref": "#/definitions/usecase.LobbyOutput"
                         }
                     },
                     "400": {
@@ -75,13 +75,13 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/domain.Lobby"
+                            "$ref": "#/definitions/usecase.LobbyOutput"
                         }
                     },
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/domain.Lobby"
+                            "$ref": "#/definitions/usecase.LobbyOutput"
                         }
                     },
                     "400": {
@@ -159,7 +159,7 @@
                     "200": {
                         "description": "lobby data",
                         "schema": {
-                            "$ref": "#/definitions/lobby.lobbyOutput"
+                            "$ref": "#/definitions/usecase.LobbyOutput"
                         }
                     },
                     "400": {
@@ -639,50 +639,6 @@
                 }
             }
         },
-        "domain.Lobby": {
-            "type": "object",
-            "properties": {
-                "createdAt": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "location": {
-                    "$ref": "#/definitions/domain.Coordinate"
-                },
-                "places": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/domain.Place"
-                    }
-                },
-                "priceAvg": {
-                    "type": "integer"
-                },
-                "state": {
-                    "type": "string"
-                },
-                "swipes": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/domain.Swipe"
-                    }
-                },
-                "tags": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/domain.Tag"
-                    }
-                },
-                "users": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/domain.User"
-                    }
-                }
-            }
-        },
         "domain.Place": {
             "type": "object",
             "properties": {
@@ -733,26 +689,6 @@
                 }
             }
         },
-        "domain.Swipe": {
-            "type": "object",
-            "properties": {
-                "cardID": {
-                    "type": "integer"
-                },
-                "id": {
-                    "type": "integer"
-                },
-                "lobbyID": {
-                    "type": "string"
-                },
-                "type": {
-                    "type": "string"
-                },
-                "userID": {
-                    "type": "string"
-                }
-            }
-        },
         "domain.Tag": {
             "type": "object",
             "properties": {
@@ -790,7 +726,29 @@
                 }
             }
         },
-        "lobby.lobbyOutput": {
+        "lobby.nearestLobbyOutput": {
+            "type": "object",
+            "properties": {
+                "distance": {
+                    "type": "number"
+                },
+                "lobby": {
+                    "$ref": "#/definitions/usecase.LobbyOutput"
+                }
+            }
+        },
+        "usecase.FindLobbyInput": {
+            "type": "object",
+            "properties": {
+                "dist": {
+                    "type": "number"
+                },
+                "location": {
+                    "$ref": "#/definitions/domain.Coordinate"
+                }
+            }
+        },
+        "usecase.LobbyOutput": {
             "type": "object",
             "properties": {
                 "createdAt": {
@@ -819,28 +777,6 @@
                     "items": {
                         "$ref": "#/definitions/domain.User"
                     }
-                }
-            }
-        },
-        "lobby.nearestLobbyOutput": {
-            "type": "object",
-            "properties": {
-                "distance": {
-                    "type": "number"
-                },
-                "lobby": {
-                    "$ref": "#/definitions/lobby.lobbyOutput"
-                }
-            }
-        },
-        "usecase.FindLobbyInput": {
-            "type": "object",
-            "properties": {
-                "dist": {
-                    "type": "number"
-                },
-                "location": {
-                    "$ref": "#/definitions/domain.Coordinate"
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -105,12 +105,33 @@ definitions:
       updatedAt:
         type: string
     type: object
+  lobby.lobbyOutput:
+    properties:
+      createdAt:
+        type: string
+      id:
+        type: string
+      location:
+        $ref: '#/definitions/domain.Coordinate'
+      priceAvg:
+        type: integer
+      state:
+        type: string
+      tags:
+        items:
+          $ref: '#/definitions/domain.Tag'
+        type: array
+      users:
+        items:
+          $ref: '#/definitions/domain.User'
+        type: array
+    type: object
   lobby.nearestLobbyOutput:
     properties:
       distance:
         type: number
       lobby:
-        $ref: '#/definitions/domain.Lobby'
+        $ref: '#/definitions/lobby.lobbyOutput'
     type: object
   usecase.FindLobbyInput:
     properties:
@@ -253,7 +274,7 @@ paths:
         "200":
           description: lobby data
           schema:
-            $ref: '#/definitions/domain.Lobby'
+            $ref: '#/definitions/lobby.lobbyOutput'
         "400":
           description: Bad Request
         "500":

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -6,35 +6,6 @@ definitions:
       lon:
         type: number
     type: object
-  domain.Lobby:
-    properties:
-      createdAt:
-        type: string
-      id:
-        type: string
-      location:
-        $ref: '#/definitions/domain.Coordinate'
-      places:
-        items:
-          $ref: '#/definitions/domain.Place'
-        type: array
-      priceAvg:
-        type: integer
-      state:
-        type: string
-      swipes:
-        items:
-          $ref: '#/definitions/domain.Swipe'
-        type: array
-      tags:
-        items:
-          $ref: '#/definitions/domain.Tag'
-        type: array
-      users:
-        items:
-          $ref: '#/definitions/domain.User'
-        type: array
-    type: object
   domain.Place:
     properties:
       address:
@@ -68,19 +39,6 @@ definitions:
       updatedAt:
         type: string
     type: object
-  domain.Swipe:
-    properties:
-      cardID:
-        type: integer
-      id:
-        type: integer
-      lobbyID:
-        type: string
-      type:
-        type: string
-      userID:
-        type: string
-    type: object
   domain.Tag:
     properties:
       icon:
@@ -105,7 +63,21 @@ definitions:
       updatedAt:
         type: string
     type: object
-  lobby.lobbyOutput:
+  lobby.nearestLobbyOutput:
+    properties:
+      distance:
+        type: number
+      lobby:
+        $ref: '#/definitions/usecase.LobbyOutput'
+    type: object
+  usecase.FindLobbyInput:
+    properties:
+      dist:
+        type: number
+      location:
+        $ref: '#/definitions/domain.Coordinate'
+    type: object
+  usecase.LobbyOutput:
     properties:
       createdAt:
         type: string
@@ -125,20 +97,6 @@ definitions:
         items:
           $ref: '#/definitions/domain.User'
         type: array
-    type: object
-  lobby.nearestLobbyOutput:
-    properties:
-      distance:
-        type: number
-      lobby:
-        $ref: '#/definitions/lobby.lobbyOutput'
-    type: object
-  usecase.FindLobbyInput:
-    properties:
-      dist:
-        type: number
-      location:
-        $ref: '#/definitions/domain.Coordinate'
     type: object
   usecase.SaveLobbyInput:
     properties:
@@ -227,7 +185,7 @@ paths:
         "200":
           description: Saved lobby
           schema:
-            $ref: '#/definitions/domain.Lobby'
+            $ref: '#/definitions/usecase.LobbyOutput'
         "400":
           description: Bad Request
         "500":
@@ -274,7 +232,7 @@ paths:
         "200":
           description: lobby data
           schema:
-            $ref: '#/definitions/lobby.lobbyOutput'
+            $ref: '#/definitions/usecase.LobbyOutput'
         "400":
           description: Bad Request
         "500":
@@ -300,11 +258,11 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/domain.Lobby'
+            $ref: '#/definitions/usecase.LobbyOutput'
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/domain.Lobby'
+            $ref: '#/definitions/usecase.LobbyOutput'
         "400":
           description: Bad Request
         "500":

--- a/internal/domain/lobby.go
+++ b/internal/domain/lobby.go
@@ -7,16 +7,16 @@ import (
 )
 
 type Lobby struct {
-	ID        string     `json:"id"`
-	State     LobbyState `json:"state"`
-	PriceAvg  int        `json:"priceAvg"`
-	Location  Coordinate `json:"location"`
-	CreatedAt time.Time  `json:"createdAt"`
+	ID        string
+	State     LobbyState
+	PriceAvg  int
+	Location  Coordinate
+	CreatedAt time.Time
 
-	Tags   []*Tag   `json:"tags"`
-	Swipes []*Swipe `json:"swipes"`
-	Users  []*User  `json:"users"`
-	Places []*Place `json:"places"`
+	Tags   []*Tag
+	Swipes []*Swipe
+	Users  []*User
+	Places []*Place
 }
 
 func (l *Lobby) TagNames() []string {

--- a/internal/gateways/http/lobby/dto.go
+++ b/internal/gateways/http/lobby/dto.go
@@ -5,6 +5,6 @@ import (
 )
 
 type nearestLobbyOutput struct {
-	Dist  float64      `json:"distance"`
+	Dist  float64              `json:"distance"`
 	Lobby *usecase.LobbyOutput `json:"lobby"`
 }

--- a/internal/gateways/http/lobby/dto.go
+++ b/internal/gateways/http/lobby/dto.go
@@ -1,35 +1,10 @@
 package lobby
 
 import (
-	"time"
-
-	"dishdash.ru/internal/domain"
+	"dishdash.ru/internal/usecase"
 )
-
-func ToLobbyOutput(lobby *domain.Lobby) *lobbyOutput {
-	return &lobbyOutput{
-		ID:        lobby.ID,
-		State:     lobby.State,
-		PriceAvg:  lobby.PriceAvg,
-		Location:  lobby.Location,
-		CreatedAt: lobby.CreatedAt,
-		Tags:      lobby.Tags,
-		Users:     lobby.Users,
-	}
-}
-
-type lobbyOutput struct {
-	ID        string            `json:"id"`
-	State     domain.LobbyState `json:"state"`
-	PriceAvg  int               `json:"priceAvg"`
-	Location  domain.Coordinate `json:"location"`
-	CreatedAt time.Time         `json:"createdAt"`
-
-	Tags  []*domain.Tag  `json:"tags"`
-	Users []*domain.User `json:"users"`
-}
 
 type nearestLobbyOutput struct {
 	Dist  float64      `json:"distance"`
-	Lobby *lobbyOutput `json:"lobby"`
+	Lobby *usecase.LobbyOutput `json:"lobby"`
 }

--- a/internal/gateways/http/lobby/dto.go
+++ b/internal/gateways/http/lobby/dto.go
@@ -1,10 +1,35 @@
 package lobby
 
 import (
+	"time"
+
 	"dishdash.ru/internal/domain"
 )
 
+func ToLobbyOutput(lobby *domain.Lobby) *lobbyOutput {
+	return &lobbyOutput{
+		ID:        lobby.ID,
+		State:     lobby.State,
+		PriceAvg:  lobby.PriceAvg,
+		Location:  lobby.Location,
+		CreatedAt: lobby.CreatedAt,
+		Tags:      lobby.Tags,
+		Users:     lobby.Users,
+	}
+}
+
+type lobbyOutput struct {
+	ID        string            `json:"id"`
+	State     domain.LobbyState `json:"state"`
+	PriceAvg  int               `json:"priceAvg"`
+	Location  domain.Coordinate `json:"location"`
+	CreatedAt time.Time         `json:"createdAt"`
+
+	Tags  []*domain.Tag  `json:"tags"`
+	Users []*domain.User `json:"users"`
+}
+
 type nearestLobbyOutput struct {
-	Dist  float64       `json:"distance"`
-	Lobby *domain.Lobby `json:"lobby"`
+	Dist  float64      `json:"distance"`
+	Lobby *lobbyOutput `json:"lobby"`
 }

--- a/internal/gateways/http/lobby/find_lobby.go
+++ b/internal/gateways/http/lobby/find_lobby.go
@@ -15,8 +15,8 @@ import (
 // @Produce  json
 // @Schemes http https
 // @Param location body usecase.FindLobbyInput true "Location + Distance (in metres)"
-// @Success 200 {object} domain.Lobby
-// @Success 201 {object} domain.Lobby
+// @Success 200 {object} lobbyOutput
+// @Success 201 {object} lobbyOutput
 // @Failure 400 "Bad Request"
 // @Failure 500 "Internal Server Error"
 // @Router /lobbies/find [post]
@@ -35,6 +35,8 @@ func FindLobby(lobbyUseCase usecase.Lobby) gin.HandlerFunc {
 			return
 		}
 
-		c.JSON(http.StatusOK, lobby)
+		lobbyOutput := ToLobbyOutput(lobby)
+
+		c.JSON(http.StatusOK, lobbyOutput)
 	}
 }

--- a/internal/gateways/http/lobby/find_lobby.go
+++ b/internal/gateways/http/lobby/find_lobby.go
@@ -15,8 +15,8 @@ import (
 // @Produce  json
 // @Schemes http https
 // @Param location body usecase.FindLobbyInput true "Location + Distance (in metres)"
-// @Success 200 {object} lobbyOutput
-// @Success 201 {object} lobbyOutput
+// @Success 200 {object} usecase.LobbyOutput
+// @Success 201 {object} usecase.LobbyOutput
 // @Failure 400 "Bad Request"
 // @Failure 500 "Internal Server Error"
 // @Router /lobbies/find [post]
@@ -35,8 +35,6 @@ func FindLobby(lobbyUseCase usecase.Lobby) gin.HandlerFunc {
 			return
 		}
 
-		lobbyOutput := ToLobbyOutput(lobby)
-
-		c.JSON(http.StatusOK, lobbyOutput)
+		c.JSON(http.StatusOK, lobby)
 	}
 }

--- a/internal/gateways/http/lobby/get_lobby_by_id.go
+++ b/internal/gateways/http/lobby/get_lobby_by_id.go
@@ -15,7 +15,7 @@ import (
 // @Produce  json
 // @Schemes http https
 // @Param id path string true "lobby ID"
-// @Success 200 {object} lobbyOutput "lobby data"
+// @Success 200 {object} usecase.LobbyOutput "lobby data"
 // @Failure 400 "Bad Request"
 // @Failure 500 "Internal Server Error"
 // @Router /lobbies/{id} [get]
@@ -23,14 +23,12 @@ func GetLobbyByID(lobbyUseCase usecase.Lobby) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		id := c.Param("id")
 
-		lobby, err := lobbyUseCase.GetLobbyByID(c, id)
+		lobby, err := lobbyUseCase.GetOutputLobbyByID(c, id)
 		if err != nil {
 			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
 		}
 
-		lobbyOutput := ToLobbyOutput(lobby);
-
-		c.JSON(http.StatusOK, lobbyOutput)
+		c.JSON(http.StatusOK, lobby)
 	}
 }

--- a/internal/gateways/http/lobby/get_lobby_by_id.go
+++ b/internal/gateways/http/lobby/get_lobby_by_id.go
@@ -15,7 +15,7 @@ import (
 // @Produce  json
 // @Schemes http https
 // @Param id path string true "lobby ID"
-// @Success 200 {object} domain.Lobby "lobby data"
+// @Success 200 {object} lobbyOutput "lobby data"
 // @Failure 400 "Bad Request"
 // @Failure 500 "Internal Server Error"
 // @Router /lobbies/{id} [get]
@@ -29,6 +29,8 @@ func GetLobbyByID(lobbyUseCase usecase.Lobby) gin.HandlerFunc {
 			return
 		}
 
-		c.JSON(http.StatusOK, lobby)
+		lobbyOutput := ToLobbyOutput(lobby);
+
+		c.JSON(http.StatusOK, lobbyOutput)
 	}
 }

--- a/internal/gateways/http/lobby/nearest_lobby.go
+++ b/internal/gateways/http/lobby/nearest_lobby.go
@@ -35,11 +35,9 @@ func NearestLobby(lobbyUseCase usecase.Lobby) gin.HandlerFunc {
 			return
 		}
 
-		lobbyOutput := ToLobbyOutput(lobby);
-
 		c.JSON(http.StatusOK, nearestLobbyOutput{
 			Dist:  dist,
-			Lobby: lobbyOutput,
+			Lobby: lobby,
 		})
 	}
 }

--- a/internal/gateways/http/lobby/nearest_lobby.go
+++ b/internal/gateways/http/lobby/nearest_lobby.go
@@ -35,9 +35,11 @@ func NearestLobby(lobbyUseCase usecase.Lobby) gin.HandlerFunc {
 			return
 		}
 
+		lobbyOutput := ToLobbyOutput(lobby);
+
 		c.JSON(http.StatusOK, nearestLobbyOutput{
 			Dist:  dist,
-			Lobby: lobby,
+			Lobby: lobbyOutput,
 		})
 	}
 }

--- a/internal/gateways/http/lobby/save_lobby.go
+++ b/internal/gateways/http/lobby/save_lobby.go
@@ -15,7 +15,7 @@ import (
 // @Produce  json
 // @Schemes http https
 // @Param lobby body usecase.SaveLobbyInput true "lobby data"
-// @Success 200 {object} lobbyOutput "Saved lobby"
+// @Success 200 {object} usecase.LobbyOutput "Saved lobby"
 // @Failure 400 "Bad Request"
 // @Failure 500 "Internal Server Error"
 // @Router /lobbies [post]
@@ -34,8 +34,6 @@ func SaveLobby(lobbyUseCase usecase.Lobby) gin.HandlerFunc {
 			return
 		}
 
-		lobbyOutput := ToLobbyOutput(lobby);
-
-		c.JSON(http.StatusOK, lobbyOutput)
+		c.JSON(http.StatusOK, lobby)
 	}
 }

--- a/internal/gateways/http/lobby/save_lobby.go
+++ b/internal/gateways/http/lobby/save_lobby.go
@@ -15,7 +15,7 @@ import (
 // @Produce  json
 // @Schemes http https
 // @Param lobby body usecase.SaveLobbyInput true "lobby data"
-// @Success 200 {object} domain.Lobby "Saved lobby"
+// @Success 200 {object} lobbyOutput "Saved lobby"
 // @Failure 400 "Bad Request"
 // @Failure 500 "Internal Server Error"
 // @Router /lobbies [post]
@@ -34,6 +34,8 @@ func SaveLobby(lobbyUseCase usecase.Lobby) gin.HandlerFunc {
 			return
 		}
 
-		c.JSON(http.StatusOK, lobby)
+		lobbyOutput := ToLobbyOutput(lobby);
+
+		c.JSON(http.StatusOK, lobbyOutput)
 	}
 }

--- a/internal/usecase/lobby.go
+++ b/internal/usecase/lobby.go
@@ -194,7 +194,6 @@ func (l LobbyUseCase) FindLobby(ctx context.Context, input FindLobbyInput) (*Lob
 			Location: input.Location,
 			PriceAvg: 500,
 		})
-
 		if err != nil {
 			return nil, err
 		}

--- a/internal/usecase/usecase.go
+++ b/internal/usecase/usecase.go
@@ -2,6 +2,7 @@ package usecase
 
 import (
 	"context"
+	"time"
 
 	"dishdash.ru/internal/domain"
 )
@@ -78,13 +79,25 @@ type FindLobbyInput struct {
 	Location domain.Coordinate `json:"location"`
 }
 
+type LobbyOutput struct {
+	ID        string            `json:"id"`
+	State     domain.LobbyState `json:"state"`
+	PriceAvg  int               `json:"priceAvg"`
+	Location  domain.Coordinate `json:"location"`
+	CreatedAt time.Time         `json:"createdAt"`
+
+	Tags  []*domain.Tag  `json:"tags"`
+	Users []*domain.User `json:"users"`
+}
+
 type Lobby interface {
-	SaveLobby(ctx context.Context, lobbyInput SaveLobbyInput) (*domain.Lobby, error)
+	SaveLobby(ctx context.Context, lobbyInput SaveLobbyInput) (*LobbyOutput, error)
 	DeleteLobbyByID(ctx context.Context, id string) error
 	GetLobbyByID(ctx context.Context, id string) (*domain.Lobby, error)
+	GetOutputLobbyByID(ctx context.Context, id string) (*LobbyOutput, error)
 
-	FindLobby(ctx context.Context, input FindLobbyInput) (*domain.Lobby, error)
-	NearestActiveLobby(ctx context.Context, loc domain.Coordinate) (*domain.Lobby, float64, error)
+	FindLobby(ctx context.Context, input FindLobbyInput) (*LobbyOutput, error)
+	NearestActiveLobby(ctx context.Context, loc domain.Coordinate) (*LobbyOutput, float64, error)
 
 	SetLobbySettings(ctx context.Context, lobbyInput UpdateLobbySettingsInput) (*domain.Lobby, error)
 	SetLobbyState(ctx context.Context, lobbyID string, state domain.LobbyState) error


### PR DESCRIPTION
Есть теория, что по хорошему большинство обращений к `GetLobbyByID()` надо переписать на `GetOutputLobbyByID()` мол на самом деле места нам надо получать очень редко, также как и свайпы собственно.

<sub><a href="https://huly.app/guest/shampsdev?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzM0MWFkZGU3Y2M1YTc4NTQyYmZmMzkiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctdGVhbS1zaGFtcHNkZXYtNjcwMTY1NjEtMWI2MmI5ZWUyNy1hOGVjMzkifQ.y61dqXc52l0VZ9GZ3NjLrqS9haoAVkyjTTth532UBVs">Huly&reg;: <b>DD-120</b></a></sub>