### PR TITLE
docs(grafana): add business stats dashboard

### DIFF
--- a/grafana/business-stats.json
+++ b/grafana/business-stats.json
@@ -1,0 +1,907 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_DISHDASH_PG",
+      "label": "dishdash postgres",
+      "description": "PostgreSQL datasource pointing at the dishdash database",
+      "type": "datasource",
+      "pluginId": "grafana-postgresql-datasource",
+      "pluginName": "PostgreSQL"
+    }
+  ],
+  "__requires": [
+    { "type": "grafana", "id": "grafana", "name": "Grafana", "version": "10.4.0" },
+    { "type": "datasource", "id": "grafana-postgresql-datasource", "name": "PostgreSQL", "version": "1.0.0" },
+    { "type": "panel", "id": "stat", "name": "Stat", "version": "" },
+    { "type": "panel", "id": "timeseries", "name": "Time series", "version": "" },
+    { "type": "panel", "id": "table", "name": "Table", "version": "" },
+    { "type": "panel", "id": "piechart", "name": "Pie chart", "version": "" },
+    { "type": "panel", "id": "geomap", "name": "Geomap", "version": "" },
+    { "type": "panel", "id": "volkovlabs-echarts-panel", "name": "Apache ECharts", "version": "" }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": { "limit": 100, "matchAny": false, "tags": [], "type": "dashboard" },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    { "collapsed": false, "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 }, "id": 33, "panels": [], "title": "Users & Activity", "type": "row" },
+    {
+      "datasource": { "type": "grafana-postgresql-datasource", "uid": "${DS_DISHDASH_PG}" },
+      "description": "Total users across all time.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "fixedColor": "green", "mode": "fixed" },
+          "decimals": 2,
+          "mappings": [],
+          "min": -3,
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "red", "value": 80 }] },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 5, "x": 0, "y": 1 },
+      "id": 25,
+      "options": {
+        "colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto",
+        "reduceOptions": { "calcs": ["sum"], "fields": "", "values": false },
+        "showPercentChange": false, "textMode": "auto", "wideLayout": true
+      },
+      "pluginVersion": "10.4.13",
+      "targets": [{
+        "datasource": { "type": "grafana-postgresql-datasource", "uid": "${DS_DISHDASH_PG}" },
+        "editorMode": "code", "format": "table", "rawQuery": true,
+        "rawSql": "SELECT DATE_TRUNC('hour', \"created_at\") AS day, COUNT(*) AS user_count FROM \"user\" GROUP BY DATE_TRUNC('hour', \"created_at\") ORDER BY day;",
+        "refId": "A"
+      }],
+      "title": "Total Users",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "grafana-postgresql-datasource", "uid": "${DS_DISHDASH_PG}" },
+      "description": "New and active users over the selected period.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text",
+            "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0,
+            "drawStyle": "line", "fillOpacity": 0, "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false, "lineInterpolation": "smooth",
+            "lineStyle": { "fill": "solid" },
+            "lineWidth": 1, "pointSize": 5, "scaleDistribution": { "type": "linear" },
+            "showPoints": "never", "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "red", "value": 80 }] }
+        },
+        "overrides": [{
+          "matcher": { "id": "byName", "options": "new_users" },
+          "properties": [{ "id": "custom.lineStyle", "value": { "dash": [10,10], "fill": "dash" } }]
+        }]
+      },
+      "gridPos": { "h": 8, "w": 9, "x": 5, "y": 1 },
+      "id": 24,
+      "maxDataPoints": 20,
+      "options": {
+        "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "single", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "grafana-postgresql-datasource", "uid": "${DS_DISHDASH_PG}" },
+          "editorMode": "code", "format": "table", "rawQuery": true,
+          "rawSql": "WITH intervals AS (SELECT generate_series($__timeFrom()::timestamp, $__timeTo()::timestamp, '${__interval}'::interval) AS ts) SELECT intervals.ts AS \"time\", COALESCE(COUNT(u.\"created_at\"), 0) AS new_users FROM intervals LEFT JOIN \"user\" u ON u.\"created_at\" >= intervals.ts AND u.\"created_at\" < intervals.ts + '${__interval}'::interval GROUP BY intervals.ts ORDER BY intervals.ts;",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "grafana-postgresql-datasource", "uid": "${DS_DISHDASH_PG}" },
+          "editorMode": "code", "format": "table", "hide": false, "rawQuery": true,
+          "rawSql": "WITH intervals AS (SELECT generate_series($__timeFrom()::timestamp, $__timeTo()::timestamp, '${__interval}'::interval) AS \"time\") SELECT intervals.\"time\" AS \"time\", COALESCE(COUNT(DISTINCT lu.user_id), 0) AS active_users FROM intervals LEFT JOIN \"lobby\" l ON l.\"created_at\" >= intervals.\"time\" AND l.\"created_at\" < intervals.\"time\" + '${__interval}'::interval LEFT JOIN \"lobby_user\" lu ON l.id = lu.lobby_id GROUP BY intervals.\"time\" ORDER BY intervals.\"time\";",
+          "refId": "B"
+        }
+      ],
+      "title": "User Activity",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "grafana-postgresql-datasource", "uid": "${DS_DISHDASH_PG}" },
+      "description": "New users in the period",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" }, "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "red", "value": 80 }] }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 2, "x": 0, "y": 9 },
+      "id": 62,
+      "options": {
+        "colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto",
+        "reduceOptions": { "calcs": ["firstNotNull"], "fields": "", "values": false },
+        "showPercentChange": false, "textMode": "auto", "wideLayout": true
+      },
+      "pluginVersion": "10.4.13",
+      "targets": [{
+        "datasource": { "type": "grafana-postgresql-datasource", "uid": "${DS_DISHDASH_PG}" },
+        "editorMode": "code", "format": "table", "rawQuery": true,
+        "rawSql": "SELECT COUNT(DISTINCT id) AS new_users FROM \"user\" as u WHERE u.created_at BETWEEN $__timeFrom() AND $__timeTo();",
+        "refId": "A"
+      }],
+      "title": "New",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "grafana-postgresql-datasource", "uid": "${DS_DISHDASH_PG}" },
+      "description": "Active users (joined a lobby) in the period.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" }, "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "red", "value": 80 }] }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 2, "x": 2, "y": 9 },
+      "id": 27,
+      "options": {
+        "colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto",
+        "reduceOptions": { "calcs": ["firstNotNull"], "fields": "", "values": false },
+        "showPercentChange": false, "textMode": "auto", "wideLayout": true
+      },
+      "pluginVersion": "10.4.13",
+      "targets": [{
+        "datasource": { "type": "grafana-postgresql-datasource", "uid": "${DS_DISHDASH_PG}" },
+        "editorMode": "code", "format": "table", "rawQuery": true,
+        "rawSql": "SELECT COUNT(DISTINCT user_id) AS active_users FROM lobby_user lu JOIN lobby l ON lu.lobby_id = l.id WHERE l.created_at BETWEEN $__timeFrom() AND $__timeTo();",
+        "refId": "A"
+      }],
+      "title": "Active",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "grafana-postgresql-datasource", "uid": "${DS_DISHDASH_PG}" },
+      "description": "Lobbies created in the period",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" }, "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "red", "value": 80 }] }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 2, "x": 4, "y": 9 },
+      "id": 60,
+      "options": {
+        "colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto",
+        "reduceOptions": { "calcs": ["firstNotNull"], "fields": "", "values": false },
+        "showPercentChange": false, "textMode": "auto", "wideLayout": true
+      },
+      "pluginVersion": "10.4.13",
+      "targets": [{
+        "datasource": { "type": "grafana-postgresql-datasource", "uid": "${DS_DISHDASH_PG}" },
+        "editorMode": "code", "format": "table", "rawQuery": true,
+        "rawSql": "SELECT COUNT(*) AS total_lobbies FROM lobby WHERE created_at BETWEEN $__timeFrom() AND $__timeTo();",
+        "refId": "A"
+      }],
+      "title": "Lobbies",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "grafana-postgresql-datasource", "uid": "${DS_DISHDASH_PG}" },
+      "description": "User count per lobby distribution",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "hideFrom": { "legend": false, "tooltip": false, "viz": false } },
+          "mappings": [{ "options": { "1 users": { "index": 0, "text": "1 user" } }, "type": "value" }],
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 5, "x": 6, "y": 9 },
+      "id": 58,
+      "options": {
+        "displayLabels": ["name"],
+        "legend": { "calcs": [], "displayMode": "hidden", "placement": "right", "showLegend": false, "values": [] },
+        "pieType": "donut",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": true },
+        "tooltip": { "mode": "single", "sort": "none" }
+      },
+      "pluginVersion": "10.4.13",
+      "targets": [{
+        "datasource": { "type": "grafana-postgresql-datasource", "uid": "${DS_DISHDASH_PG}" },
+        "editorMode": "code", "format": "table", "rawQuery": true,
+        "rawSql": "SELECT user_count::text || ' users' AS user_count_label, COUNT(*) AS lobby_count FROM (SELECT l.id AS lobby_id, COUNT(lu.user_id) AS user_count FROM lobby l LEFT JOIN lobby_user lu ON l.id = lu.lobby_id WHERE l.created_at BETWEEN $__timeFrom() AND $__timeTo() GROUP BY l.id) AS lobby_counts GROUP BY user_count ORDER BY user_count;",
+        "refId": "A"
+      }],
+      "title": "Users in lobby",
+      "transformations": [{ "id": "filterFieldsByName", "options": {} }],
+      "type": "piechart"
+    },
+    {
+      "datasource": { "type": "grafana-postgresql-datasource", "uid": "${DS_DISHDASH_PG}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text",
+            "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0,
+            "drawStyle": "line", "fillOpacity": 0, "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false, "lineInterpolation": "smooth",
+            "lineStyle": { "fill": "solid" }, "lineWidth": 1, "pointSize": 5,
+            "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "red", "value": 80 }] }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 11, "y": 9 },
+      "id": 56,
+      "maxDataPoints": 200,
+      "options": {
+        "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "single", "sort": "none" }
+      },
+      "pluginVersion": "10.4.13",
+      "targets": [{
+        "datasource": { "type": "grafana-postgresql-datasource", "uid": "${DS_DISHDASH_PG}" },
+        "editorMode": "code", "format": "table", "rawQuery": true,
+        "rawSql": "WITH base AS (SELECT COUNT(*) AS base_count FROM \"user\" WHERE created_at < $__timeFrom()), buckets AS (SELECT $__timeGroup(created_at, $__interval) AS bucket, COUNT(*) AS bucket_count FROM \"user\" WHERE created_at BETWEEN $__timeFrom() AND $__timeTo() GROUP BY bucket) SELECT bucket AS time, (SELECT base_count FROM base) + SUM(bucket_count) OVER (ORDER BY bucket) AS user_count FROM buckets ORDER BY bucket;",
+        "refId": "A"
+      }],
+      "title": "Growth",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "grafana-postgresql-datasource", "uid": "${DS_DISHDASH_PG}" },
+      "description": "Average lobbies per active user (>1 lobby in period)",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" }, "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "red", "value": 80 }] }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 3, "x": 0, "y": 13 },
+      "id": 41,
+      "options": {
+        "colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showPercentChange": false, "textMode": "auto", "wideLayout": true
+      },
+      "pluginVersion": "10.4.13",
+      "targets": [{
+        "datasource": { "type": "grafana-postgresql-datasource", "uid": "${DS_DISHDASH_PG}" },
+        "editorMode": "code", "format": "table", "rawQuery": true,
+        "rawSql": "SELECT AVG(lobby_count) AS average_lobbies FROM (SELECT u.id, COUNT(*) AS lobby_count FROM \"user\" u JOIN lobby_user lu ON u.id = lu.user_id JOIN lobby l ON l.id = lu.lobby_id WHERE l.created_at BETWEEN $__timeFrom() AND $__timeTo() GROUP BY u.id HAVING COUNT(*) > 1) AS user_lobbies;",
+        "refId": "A"
+      }],
+      "title": "Avg Lobbies By User",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "grafana-postgresql-datasource", "uid": "${DS_DISHDASH_PG}" },
+      "description": "Percent of new users who started at least one lobby",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" }, "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "red", "value": 80 }] },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 3, "x": 3, "y": 13 },
+      "id": 61,
+      "options": {
+        "colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto",
+        "reduceOptions": { "calcs": ["firstNotNull"], "fields": "", "values": false },
+        "showPercentChange": false, "textMode": "auto", "wideLayout": true
+      },
+      "pluginVersion": "10.4.13",
+      "targets": [{
+        "datasource": { "type": "grafana-postgresql-datasource", "uid": "${DS_DISHDASH_PG}" },
+        "editorMode": "code", "format": "table", "rawQuery": true,
+        "rawSql": "WITH users_in_period AS (SELECT id as user_id FROM \"user\" WHERE created_at BETWEEN $__timeFrom() AND $__timeTo()), users_with_lobby AS (SELECT DISTINCT l.user_id FROM lobby_user l JOIN users_in_period uip ON l.user_id = uip.user_id) SELECT ((COUNT(users_with_lobby.user_id) * 100.0 / COUNT(users_in_period.user_id))) AS percentage FROM users_in_period LEFT JOIN users_with_lobby ON users_in_period.user_id = users_with_lobby.user_id;",
+        "refId": "A"
+      }],
+      "title": "Active Percentage",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "grafana-postgresql-datasource", "uid": "${DS_DISHDASH_PG}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "custom": { "align": "auto", "cellOptions": { "type": "auto" }, "inspect": false },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "red", "value": 80 }] }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 9, "x": 0, "y": 17 },
+      "id": 40,
+      "options": {
+        "cellHeight": "sm",
+        "footer": { "countRows": false, "fields": "", "reducer": ["sum"], "show": false },
+        "showHeader": true
+      },
+      "pluginVersion": "10.4.13",
+      "targets": [{
+        "datasource": { "type": "grafana-postgresql-datasource", "uid": "${DS_DISHDASH_PG}" },
+        "editorMode": "code", "format": "table", "rawQuery": true,
+        "rawSql": "SELECT u.id, u.name, u.telegram, COUNT(*) AS lobby_count FROM \"user\" u JOIN lobby_user lu ON u.id = lu.user_id JOIN lobby l ON l.id = lu.lobby_id WHERE l.created_at BETWEEN $__timeFrom() AND $__timeTo() GROUP BY u.id ORDER BY lobby_count DESC",
+        "refId": "A"
+      }],
+      "title": "Active Users",
+      "type": "table"
+    },
+    {
+      "datasource": { "type": "grafana-postgresql-datasource", "uid": "${DS_DISHDASH_PG}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "custom": { "hideFrom": { "legend": false, "tooltip": false, "viz": false } },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "red", "value": 80 }] }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 9, "y": 17 },
+      "id": 34,
+      "options": {
+        "basemap": { "config": {}, "name": "Layer 0", "type": "default" },
+        "controls": { "mouseWheelZoom": true, "showAttribution": true, "showDebug": false, "showMeasure": false, "showScale": false, "showZoom": true },
+        "layers": [{
+          "config": { "blur": 15, "radius": 5, "weight": { "fixed": 1, "max": 1, "min": 0 } },
+          "location": { "mode": "auto" }, "name": "Lobbies", "tooltip": true, "type": "heatmap"
+        }],
+        "tooltip": { "mode": "details" },
+        "view": { "allLayers": true, "id": "coords", "lat": 59.93208, "lon": 30.346808, "zoom": 9.59 }
+      },
+      "pluginVersion": "10.4.13",
+      "targets": [{
+        "datasource": { "type": "grafana-postgresql-datasource", "uid": "${DS_DISHDASH_PG}" },
+        "editorMode": "code", "format": "table", "hide": false, "rawQuery": true,
+        "rawSql": "SELECT lobby_id, latitude, longitude, created_at FROM \"lobby_settings_view\" WHERE created_at BETWEEN $__timeFrom() AND $__timeTo() ORDER BY created_at DESC;",
+        "refId": "A"
+      }],
+      "title": "Lobby Map",
+      "transformations": [{
+        "id": "filterByValue",
+        "options": {
+          "filters": [
+            { "config": { "id": "between", "options": { "from": 30.312, "to": 30.314 } }, "fieldName": "lon" },
+            { "config": { "id": "between", "options": { "from": 59.945, "to": 59.947 } }, "fieldName": "lat" }
+          ],
+          "match": "all", "type": "exclude"
+        }
+      }],
+      "type": "geomap"
+    },
+    {
+      "datasource": { "type": "grafana-postgresql-datasource", "uid": "${DS_DISHDASH_PG}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "custom": { "align": "left", "cellOptions": { "type": "auto" }, "inspect": false },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "red", "value": 80 }] }
+        },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "lobbies" }, "properties": [{ "id": "custom.width", "value": 66 }] },
+          { "matcher": { "id": "byName", "options": "likes" }, "properties": [{ "id": "custom.width", "value": 66 }] },
+          { "matcher": { "id": "byName", "options": "telegram" }, "properties": [{ "id": "custom.width", "value": 106 }] },
+          { "matcher": { "id": "byName", "options": "created_at" }, "properties": [{ "id": "custom.width", "value": 179 }] },
+          { "matcher": { "id": "byName", "options": "dislikes" }, "properties": [{ "id": "custom.width", "value": 86 }] }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 7, "x": 17, "y": 17 },
+      "id": 45,
+      "options": {
+        "cellHeight": "sm",
+        "footer": { "countRows": false, "fields": "", "reducer": ["sum"], "show": false },
+        "showHeader": true, "sortBy": []
+      },
+      "pluginVersion": "10.4.13",
+      "targets": [{
+        "datasource": { "type": "grafana-postgresql-datasource", "uid": "${DS_DISHDASH_PG}" },
+        "editorMode": "code", "format": "table", "rawQuery": true,
+        "rawSql": "SELECT u.name, COALESCE(l.lobbies, 0) AS lobbies, COALESCE(s.likes, 0) AS likes, COALESCE(s.dislikes, 0) AS dislikes FROM \"user\" u LEFT JOIN (SELECT user_id, COUNT(CASE WHEN type = 'like' THEN 1 END) AS likes, COUNT(CASE WHEN type = 'dislike' THEN 1 END) AS dislikes FROM swipe GROUP BY user_id) s ON u.id = s.user_id LEFT JOIN (SELECT user_id, COUNT(*) AS lobbies FROM lobby_user GROUP BY user_id) l ON u.id = l.user_id WHERE $__timeFilter(u.created_at) ORDER BY u.created_at DESC;",
+        "refId": "A"
+      }],
+      "title": "Last Users",
+      "type": "table"
+    },
+    {
+      "datasource": { "type": "grafana-postgresql-datasource", "uid": "${DS_DISHDASH_PG}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" }, "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green" }, { "color": "red", "value": 80 }] }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 7, "w": 4, "x": 0, "y": 25 },
+      "id": 63,
+      "interval": "1d",
+      "options": {
+        "colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto",
+        "reduceOptions": { "calcs": ["count"], "fields": "/^name$/", "values": false },
+        "showPercentChange": false, "textMode": "auto", "wideLayout": true
+      },
+      "pluginVersion": "10.4.13",
+      "targets": [{
+        "datasource": { "type": "grafana-postgresql-datasource", "uid": "${DS_DISHDASH_PG}" },
+        "editorMode": "code", "format": "table", "rawQuery": true,
+        "rawSql": "SELECT DISTINCT u.id, u.name FROM lobby l JOIN lobby_user lu ON l.id = lu.lobby_id JOIN \"user\" u ON u.id = lu.user_id WHERE l.created_at BETWEEN $__timeFrom() AND $__timeTo() AND EXISTS (SELECT 1 FROM lobby_user lu2 JOIN lobby l2 ON l2.id = lu2.lobby_id WHERE lu2.user_id = u.id AND l2.created_at < $__timeFrom()) ORDER BY u.name;",
+        "refId": "A"
+      }],
+      "title": "Returning Users",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "grafana-postgresql-datasource", "uid": "${DS_DISHDASH_PG}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "custom": { "align": "auto", "cellOptions": { "type": "auto" }, "inspect": false },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green" }, { "color": "red", "value": 80 }] }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 7, "w": 11, "x": 4, "y": 25 },
+      "id": 64,
+      "options": {
+        "cellHeight": "sm",
+        "footer": { "countRows": false, "fields": "", "reducer": ["sum"], "show": false },
+        "showHeader": true
+      },
+      "pluginVersion": "10.4.13",
+      "targets": [{
+        "datasource": { "type": "grafana-postgresql-datasource", "uid": "${DS_DISHDASH_PG}" },
+        "editorMode": "code", "format": "table", "rawQuery": true,
+        "rawSql": "SELECT DISTINCT u.id, u.name FROM lobby l JOIN lobby_user lu ON l.id = lu.lobby_id JOIN \"user\" u ON u.id = lu.user_id WHERE l.created_at BETWEEN $__timeFrom() AND $__timeTo() AND EXISTS (SELECT 1 FROM lobby_user lu2 JOIN lobby l2 ON l2.id = lu2.lobby_id WHERE lu2.user_id = u.id AND l2.created_at < $__timeFrom()) ORDER BY u.name;",
+        "refId": "A"
+      }],
+      "title": "Returning Users (list)",
+      "type": "table"
+    },
+    {
+      "collapsed": true,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 32 },
+      "id": 32,
+      "panels": [
+        {
+          "datasource": { "type": "grafana-postgresql-datasource", "uid": "${DS_DISHDASH_PG}" },
+          "description": "Most popular places by likes",
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "thresholds" },
+              "custom": { "align": "auto", "cellOptions": { "type": "auto" }, "inspect": false },
+              "mappings": [],
+              "thresholds": { "mode": "absolute", "steps": [{ "color": "green" }, { "color": "red", "value": 80 }] }
+            },
+            "overrides": []
+          },
+          "gridPos": { "h": 8, "w": 7, "x": 0, "y": 41 },
+          "id": 28,
+          "options": { "cellHeight": "sm", "footer": { "countRows": false, "fields": "", "reducer": ["sum"], "show": false }, "showHeader": true },
+          "pluginVersion": "10.4.13",
+          "targets": [{
+            "datasource": { "type": "grafana-postgresql-datasource", "uid": "${DS_DISHDASH_PG}" },
+            "editorMode": "code", "format": "table", "rawQuery": true,
+            "rawSql": "SELECT p.title, COUNT(*) AS like_count FROM place p JOIN swipe s ON p.id = s.place_id JOIN lobby l ON l.id = s.lobby_id WHERE s.type = 'like' AND l.created_at BETWEEN $__timeFrom() AND $__timeTo() GROUP BY p.id ORDER BY like_count DESC;",
+            "refId": "A"
+          }],
+          "title": "Most Popular Places",
+          "type": "table"
+        },
+        {
+          "datasource": { "type": "grafana-postgresql-datasource", "uid": "${DS_DISHDASH_PG}" },
+          "description": "Most popular categories",
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "thresholds" },
+              "custom": { "align": "left", "cellOptions": { "type": "auto" }, "inspect": false },
+              "mappings": [],
+              "thresholds": { "mode": "absolute", "steps": [{ "color": "green" }, { "color": "red", "value": 80 }] }
+            },
+            "overrides": []
+          },
+          "gridPos": { "h": 8, "w": 5, "x": 7, "y": 41 },
+          "id": 36,
+          "options": { "cellHeight": "sm", "footer": { "countRows": false, "fields": "", "reducer": ["sum"], "show": false }, "showHeader": true },
+          "pluginVersion": "10.4.13",
+          "targets": [{
+            "datasource": { "type": "grafana-postgresql-datasource", "uid": "${DS_DISHDASH_PG}" },
+            "editorMode": "code", "format": "table", "rawQuery": true,
+            "rawSql": "SELECT t.name, COUNT(*) AS count FROM lobby_tag lt JOIN lobby l ON lt.lobby_id = l.id JOIN tag t ON lt.tag_id = t.id WHERE l.created_at BETWEEN $__timeFrom() AND $__timeTo() GROUP BY t.id ORDER BY count DESC",
+            "refId": "A"
+          }],
+          "title": "Popular Categories",
+          "type": "table"
+        },
+        {
+          "datasource": { "type": "grafana-postgresql-datasource", "uid": "${DS_DISHDASH_PG}" },
+          "description": "Best places by like:dislike ratio",
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "thresholds" },
+              "custom": { "align": "auto", "cellOptions": { "type": "auto" }, "inspect": false },
+              "mappings": [],
+              "thresholds": { "mode": "absolute", "steps": [{ "color": "green" }, { "color": "red", "value": 80 }] }
+            },
+            "overrides": []
+          },
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 41 },
+          "id": 31,
+          "options": { "cellHeight": "sm", "footer": { "countRows": false, "fields": "", "reducer": ["sum"], "show": false }, "showHeader": true },
+          "pluginVersion": "10.4.13",
+          "targets": [{
+            "datasource": { "type": "grafana-postgresql-datasource", "uid": "${DS_DISHDASH_PG}" },
+            "editorMode": "code", "format": "table", "rawQuery": true,
+            "rawSql": "SELECT p.title, COUNT(CASE WHEN s.type = 'like' THEN 1 END) AS like_count, COUNT(CASE WHEN s.type = 'dislike' THEN 1 END) AS dislike_count, CASE WHEN COUNT(CASE WHEN s.type = 'dislike' THEN 1 END) = 0 THEN NULL ELSE CAST(COUNT(CASE WHEN s.type = 'like' THEN 1 END) AS FLOAT) / COUNT(CASE WHEN s.type = 'dislike' THEN 1 END) END AS like_to_dislike_ratio FROM place p JOIN swipe s ON p.id = s.place_id JOIN lobby l ON l.id = s.lobby_id WHERE l.created_at BETWEEN $__timeFrom() AND $__timeTo() GROUP BY p.id ORDER BY like_to_dislike_ratio DESC NULLS LAST;",
+            "refId": "A"
+          }],
+          "title": "Most Liked Places",
+          "type": "table"
+        },
+        {
+          "datasource": { "type": "grafana-postgresql-datasource", "uid": "${DS_DISHDASH_PG}" },
+          "description": "Most shown places",
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "thresholds" },
+              "custom": { "align": "auto", "cellOptions": { "type": "auto" }, "inspect": false },
+              "mappings": [],
+              "thresholds": { "mode": "absolute", "steps": [{ "color": "green" }, { "color": "red", "value": 80 }] }
+            },
+            "overrides": []
+          },
+          "gridPos": { "h": 8, "w": 8, "x": 0, "y": 49 },
+          "id": 30,
+          "options": { "cellHeight": "sm", "footer": { "countRows": false, "fields": "", "reducer": ["sum"], "show": false }, "showHeader": true },
+          "pluginVersion": "10.4.13",
+          "targets": [{
+            "datasource": { "type": "grafana-postgresql-datasource", "uid": "${DS_DISHDASH_PG}" },
+            "editorMode": "code", "format": "table", "rawQuery": true,
+            "rawSql": "SELECT p.title, COUNT(*) AS swipe_count FROM place p JOIN swipe s ON p.id = s.place_id JOIN lobby l ON l.id = s.lobby_id WHERE l.created_at BETWEEN $__timeFrom() AND $__timeTo() GROUP BY p.id ORDER BY swipe_count DESC;",
+            "refId": "A"
+          }],
+          "title": "Most Shown Places",
+          "type": "table"
+        },
+        {
+          "datasource": { "type": "grafana-postgresql-datasource", "uid": "${DS_DISHDASH_PG}" },
+          "description": "Most added to lobbies",
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "thresholds" },
+              "custom": { "align": "auto", "cellOptions": { "type": "auto" }, "inspect": false },
+              "mappings": [],
+              "thresholds": { "mode": "absolute", "steps": [{ "color": "green" }, { "color": "red", "value": 80 }] }
+            },
+            "overrides": []
+          },
+          "gridPos": { "h": 8, "w": 7, "x": 17, "y": 49 },
+          "id": 29,
+          "options": { "cellHeight": "sm", "footer": { "countRows": false, "fields": "", "reducer": ["sum"], "show": false }, "showHeader": true },
+          "pluginVersion": "10.4.13",
+          "targets": [{
+            "datasource": { "type": "grafana-postgresql-datasource", "uid": "${DS_DISHDASH_PG}" },
+            "editorMode": "code", "format": "table", "rawQuery": true,
+            "rawSql": "SELECT p.title, COUNT(*) AS lobby_count FROM lobby l JOIN place_lobby pl ON l.id = pl.lobby_id JOIN place p ON pl.place_id = p.id GROUP BY p.id ORDER BY lobby_count DESC;",
+            "refId": "A"
+          }],
+          "title": "Most Added Places",
+          "type": "table"
+        }
+      ],
+      "title": "Places",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 33 },
+      "id": 46,
+      "panels": [
+        {
+          "datasource": { "type": "grafana-postgresql-datasource", "uid": "${DS_DISHDASH_PG}" },
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "thresholds" },
+              "custom": { "align": "auto", "cellOptions": { "type": "auto" }, "inspect": false },
+              "mappings": [],
+              "thresholds": { "mode": "absolute", "steps": [{ "color": "green" }, { "color": "red", "value": 80 }] }
+            },
+            "overrides": []
+          },
+          "gridPos": { "h": 4, "w": 16, "x": 0, "y": 50 },
+          "id": 47,
+          "options": { "cellHeight": "sm", "footer": { "countRows": false, "fields": "", "reducer": ["sum"], "show": false }, "showHeader": true, "sortBy": [] },
+          "pluginVersion": "10.4.13",
+          "targets": [{
+            "datasource": { "type": "grafana-postgresql-datasource", "uid": "${DS_DISHDASH_PG}" },
+            "editorMode": "code", "format": "table", "rawQuery": true,
+            "rawSql": "SELECT id, name, telegram, avatar, created_at FROM \"user\" WHERE telegram = '$TelegramUserID'",
+            "refId": "A"
+          }],
+          "title": "UserInfo",
+          "type": "table"
+        },
+        {
+          "datasource": { "type": "grafana-postgresql-datasource", "uid": "${DS_DISHDASH_PG}" },
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "thresholds" },
+              "custom": { "align": "auto", "cellOptions": { "type": "auto" }, "inspect": false },
+              "mappings": [],
+              "thresholds": { "mode": "absolute", "steps": [{ "color": "green" }, { "color": "red", "value": 80 }] }
+            },
+            "overrides": []
+          },
+          "gridPos": { "h": 11, "w": 8, "x": 16, "y": 50 },
+          "id": 51,
+          "options": { "cellHeight": "sm", "footer": { "countRows": false, "fields": "", "reducer": ["sum"], "show": false }, "showHeader": true, "sortBy": [] },
+          "pluginVersion": "10.4.13",
+          "targets": [{
+            "datasource": { "type": "grafana-postgresql-datasource", "uid": "${DS_DISHDASH_PG}" },
+            "editorMode": "code", "format": "table", "rawQuery": true,
+            "rawSql": "SELECT ROW_NUMBER() OVER (ORDER BY user_id) AS row_num, user_id, telegram FROM lobby_user AS lu JOIN \"user\" AS u ON u.id = lu.user_id WHERE lobby_id = '$LobbyID';",
+            "refId": "A"
+          }],
+          "title": "Users in lobby",
+          "type": "table"
+        },
+        {
+          "datasource": { "type": "grafana-postgresql-datasource", "uid": "${DS_DISHDASH_PG}" },
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "thresholds" },
+              "custom": { "align": "auto", "cellOptions": { "type": "auto" }, "inspect": false },
+              "mappings": [],
+              "thresholds": { "mode": "absolute", "steps": [{ "color": "green" }, { "color": "red", "value": 80 }] }
+            },
+            "overrides": []
+          },
+          "gridPos": { "h": 7, "w": 16, "x": 0, "y": 54 },
+          "id": 48,
+          "options": { "cellHeight": "sm", "footer": { "countRows": false, "fields": "", "reducer": ["sum"], "show": false }, "showHeader": true, "sortBy": [] },
+          "pluginVersion": "10.4.13",
+          "targets": [{
+            "datasource": { "type": "grafana-postgresql-datasource", "uid": "${DS_DISHDASH_PG}" },
+            "editorMode": "code", "format": "table", "rawQuery": true,
+            "rawSql": "SELECT * FROM lobby_user AS lu JOIN lobby AS l ON lu.lobby_id=l.id WHERE user_id IN ('$UserID') ORDER BY created_at desc LIMIT 5",
+            "refId": "A"
+          }],
+          "title": "Latest lobbies",
+          "type": "table"
+        },
+        {
+          "datasource": { "type": "grafana-postgresql-datasource", "uid": "${DS_DISHDASH_PG}" },
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "thresholds" },
+              "custom": { "align": "auto", "cellOptions": { "type": "auto" }, "inspect": false },
+              "mappings": [],
+              "thresholds": { "mode": "absolute", "steps": [{ "color": "green" }, { "color": "red", "value": 80 }] }
+            },
+            "overrides": []
+          },
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 61 },
+          "id": 50,
+          "options": { "cellHeight": "sm", "footer": { "countRows": false, "fields": "", "reducer": ["sum"], "show": false }, "showHeader": true, "sortBy": [] },
+          "pluginVersion": "10.4.13",
+          "targets": [{
+            "datasource": { "type": "grafana-postgresql-datasource", "uid": "${DS_DISHDASH_PG}" },
+            "editorMode": "code", "format": "table", "rawQuery": true,
+            "rawSql": "SELECT id, state, price_avg, CONCAT(ST_X(l.location::geometry), ', ', ST_Y(l.location::geometry)) AS lon_lat FROM lobby AS l JOIN lobby_user AS lu ON l.id = lu.lobby_id WHERE l.id = '$LobbyID'",
+            "refId": "A"
+          }],
+          "title": "Lobby info",
+          "type": "table"
+        },
+        {
+          "datasource": { "type": "grafana-postgresql-datasource", "uid": "${DS_DISHDASH_PG}" },
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "thresholds" },
+              "custom": { "hideFrom": { "legend": false, "tooltip": false, "viz": false } },
+              "mappings": [],
+              "thresholds": { "mode": "absolute", "steps": [{ "color": "green" }, { "color": "red", "value": 80 }] }
+            },
+            "overrides": []
+          },
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 61 },
+          "id": 52,
+          "options": {
+            "basemap": { "config": {}, "name": "Layer 0", "type": "default" },
+            "controls": { "mouseWheelZoom": true, "showAttribution": true, "showDebug": false, "showMeasure": false, "showScale": false, "showZoom": true },
+            "layers": [{
+              "config": {
+                "showLegend": false,
+                "style": {
+                  "color": { "fixed": "dark-green" }, "opacity": 0.4,
+                  "rotation": { "fixed": 0, "max": 360, "min": -360, "mode": "mod" },
+                  "size": { "fixed": 5, "max": 15, "min": 2 },
+                  "symbol": { "fixed": "img/icons/marker/circle.svg", "mode": "fixed" },
+                  "symbolAlign": { "horizontal": "center", "vertical": "center" },
+                  "textConfig": { "fontSize": 12, "offsetX": 0, "offsetY": 0, "textAlign": "center", "textBaseline": "middle" }
+                }
+              },
+              "location": { "mode": "auto" }, "name": "Layer 1", "tooltip": true, "type": "markers"
+            }],
+            "tooltip": { "mode": "details" },
+            "view": { "allLayers": true, "id": "zero", "lat": 0, "lon": 0, "zoom": 1 }
+          },
+          "pluginVersion": "10.4.13",
+          "targets": [{
+            "datasource": { "type": "grafana-postgresql-datasource", "uid": "${DS_DISHDASH_PG}" },
+            "editorMode": "code", "format": "table", "rawQuery": true,
+            "rawSql": "SELECT l.latitude, l.longitude FROM lobby_settings_view AS l WHERE l.lobby_id = '$LobbyID'",
+            "refId": "A"
+          }],
+          "title": "lobby location",
+          "type": "geomap"
+        },
+        {
+          "datasource": { "type": "grafana-postgresql-datasource", "uid": "${DS_DISHDASH_PG}" },
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "thresholds" }, "mappings": [],
+              "thresholds": { "mode": "percentage", "steps": [{ "color": "green" }] }
+            },
+            "overrides": []
+          },
+          "gridPos": { "h": 8, "w": 6, "x": 18, "y": 69 },
+          "id": 49,
+          "options": {
+            "colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto",
+            "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+            "showPercentChange": false, "textMode": "auto", "wideLayout": true
+          },
+          "pluginVersion": "10.4.13",
+          "targets": [{
+            "datasource": { "type": "grafana-postgresql-datasource", "uid": "${DS_DISHDASH_PG}" },
+            "editorMode": "code", "format": "table", "rawQuery": true,
+            "rawSql": "SELECT count(*) FROM lobby_user WHERE user_id = '$UserID'",
+            "refId": "A"
+          }],
+          "title": "Total user lobbies",
+          "type": "stat"
+        }
+      ],
+      "title": "Lobby",
+      "type": "row"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 34 },
+      "id": 43,
+      "panels": [],
+      "title": "Geo",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "grafana-postgresql-datasource", "uid": "${DS_DISHDASH_PG}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "custom": { "hideFrom": { "legend": false, "tooltip": false, "viz": false } },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green" }, { "color": "red", "value": 80 }] }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 35 },
+      "id": 37,
+      "options": {
+        "basemap": { "config": {}, "name": "Layer 0", "type": "default" },
+        "controls": { "mouseWheelZoom": true, "showAttribution": true, "showDebug": false, "showMeasure": false, "showScale": false, "showZoom": true },
+        "layers": [{
+          "config": {
+            "showLegend": false,
+            "style": {
+              "color": { "fixed": "blue" }, "opacity": 0.5,
+              "rotation": { "fixed": 0, "max": 360, "min": -360, "mode": "mod" },
+              "size": { "fixed": 5, "max": 15, "min": 2 },
+              "symbol": { "fixed": "img/icons/marker/circle.svg", "mode": "fixed" },
+              "symbolAlign": { "horizontal": "center", "vertical": "center" },
+              "textConfig": { "fontSize": 12, "offsetX": 0, "offsetY": 0, "textAlign": "center", "textBaseline": "middle" }
+            }
+          },
+          "location": { "mode": "auto" }, "name": "Lobbies", "tooltip": true, "type": "markers"
+        }],
+        "tooltip": { "mode": "details" },
+        "view": { "allLayers": true, "id": "coords", "lat": 59.93208, "lon": 30.346808, "zoom": 9.59 }
+      },
+      "pluginVersion": "10.4.13",
+      "targets": [{
+        "datasource": { "type": "grafana-postgresql-datasource", "uid": "${DS_DISHDASH_PG}" },
+        "editorMode": "code", "format": "table", "hide": false, "rawQuery": true,
+        "rawSql": "SELECT name, lsv.longitude AS lon, lsv.latitude AS lat FROM \"user\" u JOIN lobby_user lu ON u.id = lu.user_id JOIN lobby_settings_view lsv ON lsv.lobby_id = lu.lobby_id WHERE lsv.created_at BETWEEN $__timeFrom() AND $__timeTo();",
+        "refId": "A"
+      }],
+      "title": "Users By Lobby Location",
+      "type": "geomap"
+    },
+    {
+      "datasource": { "type": "grafana-postgresql-datasource", "uid": "${DS_DISHDASH_PG}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 35 },
+      "id": 53,
+      "options": {
+        "baidu": { "callback": "bmapReady", "key": "" },
+        "editor": { "format": "auto" },
+        "editorMode": "visual",
+        "gaode": { "key": "", "plugin": "AMap.Scale,AMap.ToolBar" },
+        "google": { "callback": "gmapReady", "key": "" },
+        "map": "json",
+        "renderer": "canvas",
+        "themeEditor": { "config": "{}", "name": "default" },
+        "visualEditor": {
+          "code": "const columns = context.panel.data.series[0].fields;\nconst numRows = columns[0].values.length;\nconst rows = [];\nfor (let i = 0; i < numRows; i++) { rows.push({ id: columns[0].values[i], source: columns[1].values[i], source_name: columns[2].values[i], target: columns[3].values[i], target_name: columns[4].values[i], weight: columns[5].values[i] }); }\nconst nodeMap = new Map();\nrows.forEach(row => { if (!nodeMap.has(row.source)) nodeMap.set(row.source, { id: row.source, name: row.source_name }); if (!nodeMap.has(row.target)) nodeMap.set(row.target, { id: row.target, name: row.target_name }); });\nconst nodes = Array.from(nodeMap.values());\nconst edges = rows.map(row => ({ source: row.source, target: row.target, value: row.weight }));\nreturn { legend: { data: [] }, series: [{ type: 'graph', layout: 'force', animation: false, label: { position: 'right', formatter: '{b}' }, draggable: true, data: nodes, force: { edgeLength: 50, repulsion: 100, gravity: 0.2 }, edges: edges }] };",
+          "dataset": [], "series": []
+        }
+      },
+      "pluginVersion": "6.5.0",
+      "targets": [{
+        "datasource": { "type": "grafana-postgresql-datasource", "uid": "${DS_DISHDASH_PG}" },
+        "editorMode": "code", "format": "table", "rawQuery": true,
+        "rawSql": "WITH user_pairs AS (SELECT LEAST(t1.user_id, t2.user_id) AS source, GREATEST(t1.user_id, t2.user_id) AS target, COUNT(DISTINCT t1.lobby_id) AS weight FROM lobby_user t1 JOIN lobby_user t2 ON t1.lobby_id = t2.lobby_id WHERE t1.user_id <> t2.user_id GROUP BY 1, 2) SELECT ROW_NUMBER() OVER (ORDER BY up.source, up.target) AS id, up.source, u1.name AS source_name, up.target, u2.name AS target_name, up.weight FROM user_pairs up JOIN \"user\" u1 ON up.source = u1.id JOIN \"user\" u2 ON up.target = u2.id ORDER BY up.source, up.target;",
+        "refId": "A"
+      }],
+      "title": "User Graph",
+      "type": "volkovlabs-echarts-panel"
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": ["dishdash"],
+  "templating": {
+    "list": [
+      {
+        "current": { "selected": false, "text": "914438292", "value": "914438292" },
+        "hide": 0, "name": "TelegramUserID",
+        "options": [{ "selected": true, "text": "914438292", "value": "914438292" }],
+        "query": "914438292", "skipUrlSync": false, "type": "textbox"
+      },
+      {
+        "current": { "selected": false, "text": "00000000-0000-0000-0000-000000000000", "value": "00000000-0000-0000-0000-000000000000" },
+        "hide": 0, "name": "UserID",
+        "options": [{ "selected": true, "text": "00000000-0000-0000-0000-000000000000", "value": "00000000-0000-0000-0000-000000000000" }],
+        "query": "00000000-0000-0000-0000-000000000000", "skipUrlSync": false, "type": "textbox"
+      },
+      {
+        "current": { "selected": false, "text": "ZA60X", "value": "ZA60X" },
+        "hide": 0, "name": "LobbyID",
+        "options": [{ "selected": true, "text": "ZA60X", "value": "ZA60X" }],
+        "query": "ZA60X", "skipUrlSync": false, "type": "textbox"
+      }
+    ]
+  },
+  "time": { "from": "now-24h", "to": "now" },
+  "timepicker": { "refresh_intervals": ["5s","10s","30s","1m","5m","15m","30m","1h","2h","1d"] },
+  "timezone": "",
+  "title": "DishDash Business Stats",
+  "uid": "dishdash-business-stats",
+  "weekStart": ""
+}


### PR DESCRIPTION
Postgres-only version of the DishDash Business Stats Grafana dashboard. Importable into any Grafana with a postgres datasource pointing at the dishdash db. Strips out Prometheus and ClickHouse panels from the swarm-era original. User Graph panel requires the volkovlabs-echarts-panel plugin.